### PR TITLE
Add Vultr deployment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ntp.log
+hmac.key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # wtigosrvr
+
+This repository provides a minimal time logger written in Go. The program
+queries several public NTP servers and records their timestamps. Each log
+entry is chained with an HMAC so tampering can be detected.
+
+## Building
+
+```
+go build ./cmd/server
+
+# build for Linux (useful for Vultr)
+GOOS=linux GOARCH=amd64 go build -o ntp-monitor ./cmd/server
+```
+
+Run with a secret key file:
+
+```
+./server -key hmac.key
+```
+
+The application periodically queries the following servers:
+
+- time.google.com
+- time.apple.com
+- time.windows.com
+- 0.ru.pool.ntp.org
+- 1.ru.pool.ntp.org
+- 2.ru.pool.ntp.org
+- 3.ru.pool.ntp.org
+
+Results are appended to `ntp.log` in JSON format.
+
+## Deploying on Vultr
+
+The repository includes example configuration files for provisioning a server.
+`vultr_api_payload.json` contains the payload used to create an instance.
+Place your API key in `vultr_config.json` and run:
+
+```
+go run vultr.go -config vultr_config.json -payload vultr_api_payload.json
+```
+
+The `readme.md` file also contains a cloud-init snippet and a macOS tray
+utility example.
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/beevik/ntp"
+)
+
+// LogEntry represents a timestamp entry with HMAC chain.
+type LogEntry struct {
+	Server     string        `json:"server"`
+	RemoteTime time.Time     `json:"remote_time"`
+	LocalTime  time.Time     `json:"local_time"`
+	Offset     time.Duration `json:"offset"`
+	KernelDiff bool          `json:"kernel_changed"`
+	MAC        string        `json:"mac"`
+}
+
+// Logger manages chained log entries.
+type Logger struct {
+	mu       sync.Mutex
+	file     *os.File
+	macKey   []byte
+	lastMAC  []byte
+	lastKxor uint64
+}
+
+func NewLogger(path string, key []byte) (*Logger, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &Logger{file: f, macKey: key}, nil
+}
+
+func (l *Logger) Close() error {
+	return l.file.Close()
+}
+
+func (l *Logger) kernelXor() uint64 {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return 0
+	}
+	fields := [][]byte{uts.Sysname[:], uts.Nodename[:], uts.Release[:], uts.Version[:], uts.Machine[:]}
+	xorVal := uint64(0)
+	for _, f := range fields {
+		for _, b := range f {
+			xorVal ^= uint64(b)
+		}
+	}
+	return xorVal
+}
+
+func (l *Logger) append(entry LogEntry) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	if _, err := l.file.Write(data); err != nil {
+		return err
+	}
+	if _, err := l.file.Write([]byte("\n")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *Logger) log(server string, resp *ntp.Response) error {
+	kxor := l.kernelXor()
+	diff := kxor != l.lastKxor
+	l.lastKxor = kxor
+
+	mac := hmac.New(sha256.New, l.macKey)
+	mac.Write(l.lastMAC)
+	fmt.Fprintf(mac, "%s|%d|%d", server, resp.Time.UnixNano(), resp.ClockOffset)
+	macSum := mac.Sum(nil)
+
+	entry := LogEntry{
+		Server:     server,
+		RemoteTime: resp.Time.UTC(),
+		LocalTime:  time.Now().UTC(),
+		Offset:     resp.ClockOffset,
+		KernelDiff: diff,
+		MAC:        hex.EncodeToString(macSum),
+	}
+
+	if err := l.append(entry); err != nil {
+		return err
+	}
+
+	l.lastMAC = macSum
+	return nil
+}
+
+func runOnce(l *Logger, server string, timeout time.Duration) error {
+	resp, err := ntp.QueryWithOptions(server, ntp.QueryOptions{Timeout: timeout})
+	if err != nil {
+		return err
+	}
+	return l.log(server, resp)
+}
+
+func main() {
+	logPath := flag.String("log", "ntp.log", "path to log file")
+	interval := flag.Duration("interval", 2*time.Second, "query interval")
+	keyFile := flag.String("key", "hmac.key", "HMAC key file")
+	flag.Parse()
+
+	key, err := os.ReadFile(*keyFile)
+	if err != nil {
+		log.Fatalf("read key: %v", err)
+	}
+
+	logger, err := NewLogger(*logPath, key)
+	if err != nil {
+		log.Fatalf("open log: %v", err)
+	}
+	defer logger.Close()
+
+	servers := []string{
+		"time.google.com",
+		"time.apple.com",
+		"time.windows.com",
+		"0.ru.pool.ntp.org",
+		"1.ru.pool.ntp.org",
+		"2.ru.pool.ntp.org",
+		"3.ru.pool.ntp.org",
+	}
+
+	ticker := time.NewTicker(*interval)
+	defer ticker.Stop()
+
+	for {
+		for _, s := range servers {
+			if err := runOnce(logger, s, *interval); err != nil {
+				fmt.Fprintln(os.Stderr, "query error", s, err)
+			}
+		}
+		<-ticker.C
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module wtigosrvr
+
+go 1.24.3
+
+require (
+	github.com/beevik/ntp v1.4.3
+	golang.org/x/sys v0.34.0
+)
+
+require golang.org/x/net v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/beevik/ntp v1.4.3 h1:PlbTvE5NNy4QHmA4Mg57n7mcFTmr1W1j3gcK7L1lqho=
+github.com/beevik/ntp v1.4.3/go.mod h1:Unr8Zg+2dRn7d8bHFuehIMSvvUYssHMxW3Q5Nx4RW5Q=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,96 @@
+Скомпилируйте приложение для Linux:
+
+GOOS=linux GOARCH=amd64 go build -o ntp-monitor
+
+Используйте cloud-init скрипт для развертывания:
+
+#cloud-config
+packages:
+  - golang
+runcmd:
+  - mkdir /opt/ntp-monitor
+  - cd /opt/ntp-monitor
+  - wget https://example.com/ntp-monitor
+  - chmod +x ntp-monitor
+  - ./ntp-monitor &
+
+
+  # /etc/systemd/system/ntp-monitor.service
+[Unit]
+Description=NTP Monitor Service
+
+[Service]
+ExecStart=/opt/ntp-monitor/ntp-monitor
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+
+	"github.com/getlantern/systray"
+)
+
+func main() {
+	systray.Run(onReady, onExit)
+}
+
+func onReady() {
+	systray.SetTitle("NTP Monitor")
+	systray.SetTooltip("NTP Server Monitoring")
+
+	mQuit := systray.AddMenuItem("Quit", "Exit application")
+
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go startMonitor(ctx)
+
+		for {
+			select {
+			case <-mQuit.ClickedCh:
+				systray.Quit()
+				return
+			}
+		}
+	}()
+}
+
+func startMonitor(ctx context.Context) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	prevXor := false
+
+	for {
+		select {
+		case <-ticker.C:
+			currentXor := xorKernelFlag()
+			if currentXor != prevXor {
+				showNotification("XOR Flag Changed", 
+					fmt.Sprintf("State changed: %v → %v", prevXor, currentXor))
+				prevXor = currentXor
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func showNotification(title, message string) {
+	exec.Command("osascript", "-e", 
+		fmt.Sprintf(`display notification "%s" with title "%s"`, message, title)).Run()
+}
+
+func onExit() {}
+
+

--- a/vultr.go
+++ b/vultr.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+type Config struct {
+	APIKey       string `json:"api_key"`
+	InstanceID   string `json:"instance_id"`
+	SSHPublicKey string `json:"ssh_public_key"`
+}
+
+func readJSON(path string, v interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+func main() {
+	cfgPath := flag.String("config", "vultr_config.json", "config file")
+	payloadPath := flag.String("payload", "vultr_api_payload.json", "payload file")
+	flag.Parse()
+
+	var cfg Config
+	if err := readJSON(*cfgPath, &cfg); err != nil {
+		log.Fatalf("read config: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := readJSON(*payloadPath, &payload); err != nil {
+		log.Fatalf("read payload: %v", err)
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Fatalf("marshal payload: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://api.vultr.com/v2/instances", bytes.NewReader(body))
+	if err != nil {
+		log.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatalf("send request: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	log.Printf("status: %s", resp.Status)
+	log.Printf("response: %s", respBody)
+}

--- a/vultr_api_payload.json
+++ b/vultr_api_payload.json
@@ -1,0 +1,16 @@
+{
+  "region": "ams",
+  "plan": "vc2-1c-1gb",
+  "os_id": 270,
+  "hostname": "ntp-monitor",
+  "label": "ntp-monitor",
+  "sshkey_id": "ssh-rsa AAA... user@host",
+  "user_data": "#cloud-config\npackage_update: true\npackages:\n  - golang\nruncmd:\n  - mkdir -p /opt/ntp-monitor\n  - cd /opt/ntp-monitor\n  - wget https://your.domain.com/releases/ntp-logger.tar.gz\n  - tar -xzvf ntp-logger.tar.gz\n  - cd ntp-logger/cmd/ntp-monitor\n  - go build -o ntp-monitor\n  - |\n    cat <<EOF > /etc/systemd/system/ntp-monitor.service\n    [Unit]\n    Description=NTP Monitor\n    [Service]\n    ExecStart=/opt/ntp-monitor/ntp-logger/cmd/ntp-monitor/ntp-monitor\n    Restart=always\n    [Install]\n    WantedBy=multi-user.target\n    EOF\n  - systemctl daemon-reexec\n  - systemctl enable ntp-monitor\n  - systemctl start ntp-monitor\n",
+  "backups": "disabled",
+  "enable_ipv6": true,
+  "tags": [
+    "ntp",
+    "monitor"
+  ],
+  "script_id": null
+}

--- a/vultr_config.json
+++ b/vultr_config.json
@@ -1,0 +1,5 @@
+{
+  "api_key": "ВАШ_VULTR_API_KEY",
+  "instance_id": "vultr-instance-id",
+  "ssh_public_key": "ssh-rsa AAA... user@host"
+}


### PR DESCRIPTION
## Summary
- keep config and docs from `main`
- add `vultr.go` helper to provision a Vultr instance
- extend README with Vultr deployment instructions

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877599d7314832898612628a57d6860